### PR TITLE
Removed extra python install in runner image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -38,11 +38,6 @@ ENV DEBIAN_FRONTEND=nonintercative
 RUN apt-get update \
     && apt-get install --no-install-recommends -y \
     curl \
-    build-essential \
-    python3.11-distutils \
-    python3-pip \
-    python3-setuptools \
-    python3-dev \
     libmariadb-dev-compat \
     && rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
### Description

Poetry failing to install via curl.

### (Probable) Cause 

Duplicative python3 install in runner-image.

The base image is python3.11, so I don't believe the python3 install in the runner-image is needed.

### Solution

Remove Dockerfile lines 45-45

### Comments

I just found this repo last night, so please let me know if I've gone awry. 

### Logs

Command:
`docker build . --target=prod --build-arg BASE_IMAGE=python:3.11-slim -t iceberg-rest-base`

Docker Build Error:
```
 => [internal] load build definition from Dockerfile                                                                                                                                                                                                                      0.0s
 => => transferring dockerfile: 1.26kB                                                                                                                                                                                                                                    0.0s
 => [internal] load metadata for docker.io/library/python:3.11                                                                                                                                                                                                            0.7s
 => [auth] library/python:pull token for registry-1.docker.io                                                                                                                                                                                                             0.0s
 => [internal] load .dockerignore                                                                                                                                                                                                                                         0.0s
 => => transferring context: 2B                                                                                                                                                                                                                                           0.0s
 => [runtime-base 1/2] FROM docker.io/library/python:3.11@sha256:01b1035a2912ade481cf6db2381dc10c97ee19a4f670b056138517e22d8ea1c5                                                                                                                                         0.0s
 => CACHED [runtime-base 2/2] RUN apt-get update && apt-get install --no-install-recommends -y     curl     && rm -rf /var/lib/apt/lists/*                                                                                                                                0.0s
 => CACHED [build-base 1/2] RUN apt-get update     && apt-get install --no-install-recommends -y     curl     build-essential     python3.11-distutils     python3-pip     python3-setuptools     python3-dev     libmariadb-dev-compat     && rm -rf /var/lib/apt/lists  0.0s
 => ERROR [build-base 2/2] RUN curl -sSL https://install.python-poetry.org/ | python3 -

> [build-base 2/3] RUN curl -sSL https://install.python-poetry.org/ | python3:
20.95 Retrieving Poetry metadata
20.95
20.95 # Welcome to Poetry!
20.95
20.95 This will download and install the latest version of Poetry,
20.95 a dependency and package manager for Python.
20.95
20.95 It will add the `poetry` command to Poetry's bin directory, located at:
20.95
20.95 /opt/poetry/bin
20.95
20.95 You can uninstall at any time by executing this script with the --uninstall option,
20.95 and these changes will be reverted.
20.95
20.95 Installing Poetry (1.8.3)
20.95 Installing Poetry (1.8.3): Creating environment
20.95 Installing Poetry (1.8.3): Installing Poetry
20.95 Installing Poetry (1.8.3): An error occurred. Removing partial environment.
20.95 Poetry installation failed.
20.95 See /home/iceberg/iceberg_rest/poetry-installer-error-wb07wq8d.log for error logs.
------
Dockerfile:52
--------------------
  50 |     ENV POETRY_HOME=${POETRY_HOME} \
  51 |         POETRY_VERSION=${POETRY_VERSION}
  52 | >>> RUN curl -sSL https://install.python-poetry.org/ | python3
  53 |
  54 |     # Add Poetry to the path
--------------------
ERROR: failed to solve: process "/bin/bash -c curl -sSL https://install.python-poetry.org/ | python3" did not complete successfully: exit code: 1
```



To retrieve the logfile I commented out everything in the Dockerfile after line 51, reran the build command, and finally ran an interactive shell:

`docker run -it  iceberg-rest-base /bin/bash`


```
root@5a3dab909bed:/# curl -sSL https://install.python-poetry.org/ | python3
Retrieving Poetry metadata

# Welcome to Poetry!

This will download and install the latest version of Poetry,
a dependency and package manager for Python.

It will add the `poetry` command to Poetry's bin directory, located at:

/opt/poetry/bin

You can uninstall at any time by executing this script with the --uninstall option,
and these changes will be reverted.

Installing Poetry (1.8.3): An error occurred. Removing partial environment.
Poetry installation failed.
See /poetry-installer-error-stn057bu.log for error logs.
root@5a3dab909bed:/# cat /poetry-installer-error-stn057bu.log
WARNING: pip is configured with locations that require TLS/SSL, however the ssl module in Python is not available.
WARNING: Retrying (Retry(total=4, connect=None, read=None, redirect=None, status=None)) after connection broken by 'SSLError("Can't connect to HTTPS URL because the SSL module is not available.")': /simple/poetry/
WARNING: Retrying (Retry(total=3, connect=None, read=None, redirect=None, status=None)) after connection broken by 'SSLError("Can't connect to HTTPS URL because the SSL module is not available.")': /simple/poetry/
WARNING: Retrying (Retry(total=2, connect=None, read=None, redirect=None, status=None)) after connection broken by 'SSLError("Can't connect to HTTPS URL because the SSL module is not available.")': /simple/poetry/
WARNING: Retrying (Retry(total=1, connect=None, read=None, redirect=None, status=None)) after connection broken by 'SSLError("Can't connect to HTTPS URL because the SSL module is not available.")': /simple/poetry/
WARNING: Retrying (Retry(total=0, connect=None, read=None, redirect=None, status=None)) after connection broken by 'SSLError("Can't connect to HTTPS URL because the SSL module is not available.")': /simple/poetry/
Could not fetch URL https://pypi.org/simple/poetry/: There was a problem confirming the ssl certificate: HTTPSConnectionPool(host='pypi.org', port=443): Max retries exceeded with url: /simple/poetry/ (Caused by SSLError("Can't connect to HTTPS URL because the SSL module is not available.")) - skipping
ERROR: Could not find a version that satisfies the requirement poetry==1.8.3 (from versions: none)
ERROR: No matching distribution found for poetry==1.8.3
WARNING: pip is configured with locations that require TLS/SSL, however the ssl module in Python is not available.
Could not fetch URL https://pypi.org/simple/pip/: There was a problem confirming the ssl certificate: HTTPSConnectionPool(host='pypi.org', port=443): Max retries exceeded with url: /simple/pip/ (Caused by SSLError("Can't connect to HTTPS URL because the SSL module is not available.")) - skipping

Traceback:

  File "<stdin>", line 923, in main
  File "<stdin>", line 560, in run
  File "<stdin>", line 582, in install
  File "<stdin>", line 685, in install_poetry
  File "<stdin>", line 375, in pip
  File "<stdin>", line 372, in python
  File "<stdin>", line 365, in run
```